### PR TITLE
Added German translation

### DIFF
--- a/lang/de.js
+++ b/lang/de.js
@@ -1,0 +1,7 @@
+/**
+ * @license Copyright (c) 2003-2014, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or http://ckeditor.com/license
+ */
+CKEDITOR.plugins.setLang( 'openlink', 'de', {
+	menu: 'Link in neuem Tab öffnen'
+} );


### PR DESCRIPTION
The translation conforms with the "open link in new tab" translation in the Google Chrome Browser.