### PR TITLE
Added config option "openlink_defaultTarget"

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -20,6 +20,10 @@
 		requires: 'link,contextmenu',
 
 		init: function( editor ) {
+			if(!editor.config.openlink_defaultTarget){
+				editor.config.openlink_defaultTarget = "_blank";
+			}
+
 			// Register openLink command.
 			editor.addCommand( 'openLink', {
 				exec: function( editor ) {
@@ -86,7 +90,8 @@
 					}
 					
 					if ( href && modifierPressed ) {
-						window.open( href, '_blank' );
+
+						window.open( href, editor.config.openlink_defaultTarget );
 					}
 				} );
 			} );


### PR DESCRIPTION
This config option sets the target for opening links. It makes it possible to open links in the same window (by using target _self).
