### PR TITLE
added swiss-german translation

### DIFF
--- a/lang/de-ch.js
+++ b/lang/de-ch.js
@@ -1,0 +1,7 @@
+/**
+ * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or http://ckeditor.com/license
+ */
+CKEDITOR.plugins.setLang( 'openlink', 'de-ch', {
+	menu: 'Link öffnen'
+} );

--- a/plugin.js
+++ b/plugin.js
@@ -13,7 +13,7 @@
 ( function() {
 
 	CKEDITOR.plugins.add( 'openlink', {
-		lang: 'bg,en,de,pl,ru,uk', // %REMOVE_LINE_CORE%
+		lang: 'bg,en,de,de-ch,pl,ru,uk', // %REMOVE_LINE_CORE%
 		icons: 'openLink', // %REMOVE_LINE_CORE%
 		hidpi: true, // %REMOVE_LINE_CORE%
 		requires: 'link,contextmenu',


### PR DESCRIPTION
I've added the swiss german translation, because if you initialize the editor with swiss german, the plugin uses the default language which is english. Currently there's no difference to the german translation.